### PR TITLE
Don't use idents as ignore dirs or asset dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ The crate automatically handles:
 
 ### Required parameter
 
-- `path_to_dir` - a valid Rust identifier or `&str` of the path to the static files to be included
+- `path_to_dir` - a valid `&str` string literal of the path to the static files to be included
 
 ### Optional parameters
 
 - `compress = false` - compress static files with zstd and gzip, true or false (defaults to false)
 
-- `ignore_dirs = [my_ignore_dir, other_ignore_dir]` - a bracketed list of valid Rust identifiers or `&str`s of the paths/subdirectories inside the target directory, which should be ignored and not included. (If this parameter is missing, no subdirectories will be ignored)
+- `ignore_dirs = [my_ignore_dir, other_ignore_dir]` - a bracketed list of `&str`s of the paths/subdirectories inside the target directory, which should be ignored and not included. (If this parameter is missing, no subdirectories will be ignored)
 
 ## Example
 

--- a/static-serve/README.md
+++ b/static-serve/README.md
@@ -46,12 +46,12 @@ The crate automatically handles:
 
 ### Required parameter
 
-- `path_to_dir` - a valid Rust identifier or `&str` of the path to the static files to be included
+- `path_to_dir` - a valid `&str` string literal of the path to the static files to be included
 
 ### Optional parameters
 
 - `compress = false` - compress static files with zstd and gzip, true or false (defaults to false)
-- `ignore_dirs = [my_ignore_dir, other_ignore_dir]` - a bracketed list of valid Rust identifiers or `&str`s of the paths/subdirectories inside the target directory, which should be ignored and not included. (If this parameter is missing, no subdirectories will be ignored)
+- `ignore_dirs = [my_ignore_dir, other_ignore_dir]` - a bracketed list of `&str`s of the paths/subdirectories inside the target directory, which should be ignored and not included. (If this parameter is missing, no subdirectories will be ignored)
 
 ## Example
 


### PR DESCRIPTION
I found that we weren't actually allowing valid Rust idents as ignored directories, and I remember we didn't test this in the integration tests because we didn't have any valid identifiers to use in that scope, so I wrote some unit tests inside the macro crate to test it there.