### PR TITLE
  feat!: add ignore_paths parameter (replaces ignore_dirs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ This will:
 
 - `compress = false` - compress static files with zstd and gzip, true or false (defaults to false)
 
-- `ignore_dirs = ["my_ignore_dir", "other_ignore_dir"]` - a bracketed list of `&str`s of the paths/subdirectories inside the target directory, which should be ignored and not included. (If this parameter is missing, no subdirectories will be ignored)
-
-- `ignore_files = ["my_ignore_file.txt", "other_ignore_file.js"]` - a bracketed list of `&str`s of the specific files inside the target directory, which should be ignored and not included. (If this parameter is missing, no files will be ignored)
+- `ignore_paths = ["my_ignore_dir", "other_ignore_dir", "my_ignore_file.txt"]` - a bracketed list of `&str`s of paths/subdirectories/files inside the target directory, which should be ignored and not included. (If this parameter is missing, no paths/subdirectories/files will be ignored)
 
 - `strip_html_ext = false` - strips the `.html` or `.htm` from all HTML files included. If the filename is `index.html` or `index.htm`, the `index` part will also be removed, leaving just the root (defaults to false)
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Use the `embed_assets!` macro to create a `static_router()` function in scope wh
 ```rust
 use static_serve::embed_assets;
 
-embed_assets!("assets", compress = true, ignore_files = ["temp.txt"], cache_busted_paths = ["immutable"]);
+embed_assets!("assets", compress = true, ignore_paths = ["temp.txt","temp"], cache_busted_paths = ["immutable"]);
 let router = static_router();
 ```
 
 This will:
 
-- Include all files from the `assets` directory except `temp.txt`
+- Include all files from the `assets` directory except `temp.txt` and the `temp` directory
 - Compress them using `gzip` and `zstd` (if beneficial)
 - For only files in `assets/immutable`, add a `Cache-Control` header with `public, max-age=31536000, immutable` (since these are marked as cache-busted paths)
 - Generate a `static_router()` function to serve these assets

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ Use the `embed_assets!` macro to create a `static_router()` function in scope wh
 ```rust
 use static_serve::embed_assets;
 
-embed_assets!("assets", compress = true, cache_busted_paths = ["immutable"]);
+embed_assets!("assets", compress = true, ignore_files = ["temp.txt"], cache_busted_paths = ["immutable"]);
 let router = static_router();
 ```
 
 This will:
 
-- Include all files from the `assets` directory
+- Include all files from the `assets` directory except `temp.txt`
 - Compress them using `gzip` and `zstd` (if beneficial)
 - For only files in `assets/immutable`, add a `Cache-Control` header with `public, max-age=31536000, immutable` (since these are marked as cache-busted paths)
 - Generate a `static_router()` function to serve these assets
@@ -51,6 +51,8 @@ This will:
 - `compress = false` - compress static files with zstd and gzip, true or false (defaults to false)
 
 - `ignore_dirs = ["my_ignore_dir", "other_ignore_dir"]` - a bracketed list of `&str`s of the paths/subdirectories inside the target directory, which should be ignored and not included. (If this parameter is missing, no subdirectories will be ignored)
+
+- `ignore_files = ["my_ignore_file.txt", "other_ignore_file.js"]` - a bracketed list of `&str`s of the specific files inside the target directory, which should be ignored and not included. (If this parameter is missing, no files will be ignored)
 
 - `strip_html_ext = false` - strips the `.html` or `.htm` from all HTML files included. If the filename is `index.html` or `index.htm`, the `index` part will also be removed, leaving just the root (defaults to false)
 

--- a/static-serve-macro/src/error.rs
+++ b/static-serve-macro/src/error.rs
@@ -21,8 +21,8 @@ pub(crate) enum Error {
     FilePathIsNotUtf8,
     #[error("Invalid unicode in directory name")]
     InvalidUnicodeInDirectoryName,
-    #[error("Cannot canonicalize ignore directory")]
-    CannotCanonicalizeIgnoreDir(#[source] io::Error),
+    #[error("Cannot canonicalize ignore path")]
+    CannotCanonicalizeIgnorePath(#[source] io::Error),
     #[error("Invalid unicode in directory name")]
     InvalidUnicodeInEntryName,
     #[error("Error while compressing with gzip")]

--- a/static-serve/tests/tests.rs
+++ b/static-serve/tests/tests.rs
@@ -1081,7 +1081,7 @@ async fn handles_dir_with_cache_control_on_filename_and_dir() {
 }
 
 #[tokio::test]
-async fn router_created_ignore_files() {
+async fn router_created_ignore_paths() {
     embed_assets!(
         "../static-serve/test_assets/small",
         ignore_paths = ["app.js"]

--- a/static-serve/tests/tests.rs
+++ b/static-serve/tests/tests.rs
@@ -208,8 +208,8 @@ async fn router_created_compressed_zstd_or_gzip_accepted() {
 }
 
 #[tokio::test]
-async fn router_created_ignore_dirs_one() {
-    embed_assets!("../static-serve/test_assets", ignore_dirs = ["dist"]);
+async fn router_created_ignore_paths_one() {
+    embed_assets!("../static-serve/test_assets", ignore_paths = ["dist"]);
     let router: Router<()> = static_router();
     assert!(router.has_routes());
 
@@ -230,10 +230,10 @@ async fn router_created_ignore_dirs_one() {
 }
 
 #[tokio::test]
-async fn router_created_ignore_dirs_three() {
+async fn router_created_ignore_paths_three() {
     embed_assets!(
         "../static-serve/test_assets",
-        ignore_dirs = ["big", "small", "dist", "with_html"]
+        ignore_paths = ["big", "small", "dist", "with_html"]
     );
     let router: Router<()> = static_router();
     // all directories ignored, so router has no routes
@@ -1084,20 +1084,20 @@ async fn handles_dir_with_cache_control_on_filename_and_dir() {
 async fn router_created_ignore_files() {
     embed_assets!(
         "../static-serve/test_assets/small",
-        ignore_files = ["app.js"]
+        ignore_paths = ["app.js"]
     );
     let router: Router<()> = static_router();
 
     // app.js should be ignored, but styles.css should be available
     assert!(router.has_routes());
 
-    // Request for app.js should succeed
+    // Request for styles.css should succeed
     let request = create_request("/styles.css", &Compression::None);
     let response = get_response(router.clone(), request).await;
     let (parts, _) = response.into_parts();
     assert!(parts.status.is_success());
 
-    // Request for index.html should return 404 since it's ignored
+    // Request for app.js should return 404 since it's ignored
     let request = create_request("/app.js", &Compression::None);
     let response = get_response(router, request).await;
     let (parts, _) = response.into_parts();
@@ -1108,11 +1108,11 @@ async fn router_created_ignore_files() {
 async fn router_created_ignore_multiple_files() {
     embed_assets!(
         "../static-serve/test_assets/big",
-        ignore_files = ["app.js", "styles.css"]
+        ignore_paths = ["app.js", "styles.css"]
     );
     let router: Router<()> = static_router();
 
-    // All files in /big should be ignored, but files in /big/immutable should still be available
+    // app.js and styles.css at root should be ignored, but files in /big/immutable should still be available
     assert!(router.has_routes());
 
     // Request for ignored files should return 404


### PR DESCRIPTION
I wanted to serve my index.html differently than the rest of my static files.
(to add a middleware on / )

After hours of pain, and trying other libraries. I thought an option was to have an ignore_files option.
That way you can ignore those files, and serve things how you want.


Perhaps there is a smarter way to setup my project, will try to play with it a bit to see if it is actually useful.