### PR TITLE
feat: Add `allow_unknown_extensions` macro param

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ This will:
 
 - `cache_busted_paths = ["my_immutables_dir", "my_immutable_file"]` - a bracketed list of `&str`s of the subdirectories and/or single files which should gain the `Cache-Control` header with `public, max-age=31536000, immutable` for cache-busted paths. If this parameter is missing, the default is that no embedded files will have the `Cache-Control` header. Note: the files in `cache_busted_paths` need to already be compatible with cache-busting by having hashes in their file paths (for example). All `static-serve` does is set the appropriate header. 
 
+- `allow_unknown_extensions = false` - serve files with unknown extensions as `application/octet-stream` content-type; when not set to `true`, compilation fails if a content type cannot be guessed from the extension, or if the file has no extension
+
 ### Embedding a single static asset file
 
 Use the `embed_asset!` macro to return a function you can use as a GET handler, which will include your static file, embedded into your binary:
@@ -85,6 +87,7 @@ This will:
 
 - `compress = false` - compress a static file with zstd and gzip, true or false (defaults to false)
 - `cache_bust = false` - add a `Cache-Control` header with the value `public, max-age=31536000, immutable` for a cache-busted asset (defaults to false)
+- `allow_unknown_extensions = false` - serve files with unknown extensions as `application/octet-stream` content-type; when not set to `true`, compilation   fails if a content type cannot be guessed from the extension, or if the file has no extension
 
 ## Conditional Requests & Caching
 

--- a/static-serve-macro/src/lib.rs
+++ b/static-serve-macro/src/lib.rs
@@ -25,6 +25,17 @@ use error::{Error, GzipType, ZstdType};
 
 #[proc_macro]
 /// Embed and optionally compress static assets for a web server
+///
+/// ```compile_fail,hidden
+/// # // The corresponding successful test is in static-serve/tests/tests.rs,
+/// # // where tests usually belong. It's called serves_unknown_attributes.
+/// # // But only doctests support the `compile_fail` attribute so the failing
+/// # // test is placed here.
+/// embed_assets!(
+///     "../static-serve/test_unknown_extensions",
+///     allow_unknown_extensions = false
+/// );
+/// ```
 pub fn embed_assets(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let parsed = parse_macro_input!(input as EmbedAssets);
     quote! { #parsed }.into()

--- a/test_unknown_extensions/example.wtf
+++ b/test_unknown_extensions/example.wtf
@@ -1,0 +1,1 @@
+example.wtf


### PR DESCRIPTION
Not sure if that's how you want to do things but i find it annoying that my program doesn't compile when there is an unknown extension.

In my daily usage it's not been a **great** problem but lately i've been working with a person who uses MacOS so there's `.DS_STORE` files everywhere preventing compilation.

in this PR i add an `infallible` feature flag which uses mimetype `binary/octet-stream` when it cannot be guessed, instead of crashing compilation.