### PR TITLE
Fix allow_unknown_extensions = true

### DIFF
--- a/static-serve-macro/src/lib.rs
+++ b/static-serve-macro/src/lib.rs
@@ -790,11 +790,13 @@ fn maybe_get_compressed(compressed: &[u8], contents: &[u8]) -> Option<LitByteStr
 /// We accept the first guess because [`mime_guess` updates the order
 /// according to the latest IETF RTC](https://docs.rs/mime_guess/2.0.5/mime_guess/struct.MimeGuess.html#note-ordering)
 fn file_content_type(path: &Path, allow_unknown_extensions: bool) -> Result<String, error::Error> {
-    let ext = path.extension().ok_or(if allow_unknown_extensions {
-        return Ok(mime_guess::mime::APPLICATION_OCTET_STREAM.to_string());
-    } else {
-        error::Error::UnknownFileExtension(None)
-    })?;
+    let Some(ext) = path.extension() else {
+        return if allow_unknown_extensions {
+            Ok(mime_guess::mime::APPLICATION_OCTET_STREAM.to_string())
+        } else {
+            Err(error::Error::UnknownFileExtension(None))
+        };
+    };
 
     let ext = ext
         .to_str()

--- a/static-serve/tests/tests.rs
+++ b/static-serve/tests/tests.rs
@@ -1369,3 +1369,26 @@ async fn serves_unknown_extensions() {
         .to_vec();
     assert_eq!(&collected_body_bytes, &b"example.wtf");
 }
+
+// Reproducing Test. Expected to panic.
+#[should_panic(expected = "application/octet-stream")]
+#[tokio::test]
+async fn allow_unknown_extensions_must_retain_content_type_for_known_extensions() {
+    // Given a router embedding assets with `allow_unknown_extensions = true` and a file with known
+    // extensions (in this case, `app.js`)
+    embed_assets!(
+        "../static-serve/test_assets/small",
+        allow_unknown_extensions = true
+    );
+    let router: Router<()> = static_router();
+
+    // When requesting `.app.js` from the router
+    let request = create_request("/app.js", &Compression::None);
+    let response = get_response(router.clone(), request).await;
+
+    // Then the content type must be `application/javascript`
+    assert_eq!(
+        "application/javascript",
+        response.headers().get("content-type").unwrap()
+    );
+}

--- a/static-serve/tests/tests.rs
+++ b/static-serve/tests/tests.rs
@@ -1370,8 +1370,6 @@ async fn serves_unknown_extensions() {
     assert_eq!(&collected_body_bytes, &b"example.wtf");
 }
 
-// Reproducing Test. Expected to panic.
-#[should_panic(expected = "application/octet-stream")]
 #[tokio::test]
 async fn allow_unknown_extensions_must_retain_content_type_for_known_extensions() {
     // Given a router embedding assets with `allow_unknown_extensions = true` and a file with known
@@ -1388,7 +1386,7 @@ async fn allow_unknown_extensions_must_retain_content_type_for_known_extensions(
 
     // Then the content type must be `application/javascript`
     assert_eq!(
-        "application/javascript",
+        "text/javascript",
         response.headers().get("content-type").unwrap()
     );
 }


### PR DESCRIPTION
Hello Dear Maintainers,

thanks for this crate. I like it a lot. I already use it in a pet project of mine. I can not yet use it in my dayjob though. Responsible is this bug:

`allow_unknown_extensions = true` currently sets all `content-type` headers to `application/octet-stream`. Even if their mime type is known.

This PR provides a reproducing test and a fix.

Best, Markus